### PR TITLE
Some improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ function copy(text) {
     var range = document.createRange();
     var selection = document.getSelection();
 
-    var mark = document.createElement("mark");
+    var mark = document.createElement('mark');
     mark.textContent = text;
     document.body.appendChild(mark);
 
@@ -14,13 +14,13 @@ function copy(text) {
     if (!successful) {
       throw new Error('copy command was unsuccessful');
     }
-  } catch(err) {
+  } catch (err) {
     console.error('unable to copy, trying IE specific stuff');
     try {
-      window.clipboardData.setData("Text", text);
-    } catch(err) {
+      window.clipboardData.setData('text', text);
+    } catch (err) {
       console.error('unable to copy, falling back to prompt');
-      window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
+      window.prompt('Copy to clipboard: Ctrl+C, Enter', text);
     }
   } finally {
     if (typeof selection.removeRange == 'function') {

--- a/index.js
+++ b/index.js
@@ -23,12 +23,18 @@ function copy(text) {
       window.prompt('Copy to clipboard: Ctrl+C, Enter', text);
     }
   } finally {
-    if (typeof selection.removeRange == 'function') {
-      selection.removeRange(range);
-    } else {
-      selection.removeAllRanges();
+    if (selection) {
+      if (typeof selection.removeRange == 'function') {
+        selection.removeRange(range);
+      } else {
+        selection.removeAllRanges();
+      }
     }
-    document.body.removeChild(mark);
+
+    if (mark) {
+      document.body.removeChild(mark);
+    }
   }
 }
+
 module.exports = copy;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function copy(text) {
   try {
     var successful = document.execCommand('copy');
     if (!successful) {
-      throw(new Error('copy command was unsuccessful'));
+      throw new Error('copy command was unsuccessful');
     }
   } catch(err) {
     console.error('unable to copy, trying IE specific stuff');

--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@ function copy(text) {
   var range = document.createRange();
   var newDiv = document.createElement("div");
   var newContent = document.createTextNode(text);
+  var selection = window.getSelection();
   newDiv.appendChild(newContent);
   document.body.appendChild(newDiv);
   range.selectNode(newDiv);
-  window.getSelection().addRange(range);
+  selection.addRange(range);
   try {
     var successful = document.execCommand('copy');
     if (!successful) {
@@ -20,10 +21,12 @@ function copy(text) {
       window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
     }
   } finally {
-    // Remove the selections - NOTE: Should use
-    // removeRange(range) when it is supported
+    if (typeof selection.removeRange == 'function') {
+      selection.removeRange(range);
+    } else {
+      selection.removeAllRanges();
+    }
     document.body.removeChild(newDiv);
-    window.getSelection().removeAllRanges();
   }
 }
 module.exports = copy;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 function copy(text) {
-  var range = document.createRange();
-  var newDiv = document.createElement("div");
-  var newContent = document.createTextNode(text);
-  var selection = window.getSelection();
-  newDiv.appendChild(newContent);
-  document.body.appendChild(newDiv);
-  range.selectNode(newDiv);
-  selection.addRange(range);
   try {
+    var range = document.createRange();
+    var selection = document.getSelection();
+
+    var mark = document.createElement("mark");
+    mark.textContent = text;
+    document.body.appendChild(mark);
+
+    range.selectNode(mark);
+    selection.addRange(range);
+
     var successful = document.execCommand('copy');
     if (!successful) {
       throw new Error('copy command was unsuccessful');
@@ -17,7 +19,7 @@ function copy(text) {
     try {
       window.clipboardData.setData("Text", text);
     } catch(err) {
-      console.error('unable to copy, fallback to prompt');
+      console.error('unable to copy, falling back to prompt');
       window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
     }
   } finally {
@@ -26,7 +28,7 @@ function copy(text) {
     } else {
       selection.removeAllRanges();
     }
-    document.body.removeChild(newDiv);
+    document.body.removeChild(mark);
   }
 }
 module.exports = copy;


### PR DESCRIPTION
Take a look at commits messages for more details.

Inline `mark` instead of block `div` fixes Chrome 43 (or even 44) issue with including line break before actual `text`.

Tested in IE 8/XP, IE 9/7, IE 10/8, Chrome 43/45/OS X.