### PR TITLE
add `repository` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   ],
   "author": "sudodoki <smd.deluzion@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sudodoki/copy-to-clipboard"
+  },
   "contributors": [
     {
       "name": "Aleksej Shvajka",


### PR DESCRIPTION
This both silences an npm warning, and allows the package page to link back to the repo.