### PR TITLE
Allow multiline content

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function copy(text) {
     selection = document.getSelection();
 
     mark = document.createElement('mark');
-    mark.innerHTML = text;
+    mark.innerHTML = text.replace(/\n/g, '<br />');
     document.body.appendChild(mark);
 
     range.selectNode(mark);


### PR DESCRIPTION
In the current implementation, if your text content has some line returns (\n), then the text copied into the clipboard will turn them into spaces (since in HTML, a line return doesn't mean anything).
This fixes it: it will replace any line return by an HTML br before copy to the clipboard, which the browser will render as a proper line return.