### PR TITLE
TypeScript: Added missing return type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
 // Type definitions for copy-to-clipboard 3.0
 // Project: https://github.com/sudodoki/copy-to-clipboard
-// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions by: Denis Carriere <https://github.com/DenisCarriere>, MartynasZilinskas <https://github.com/MartynasZilinskas>
 
 interface Options {
   debug?: boolean;
   message?: string;
 }
 
-declare function copy(text: string, options?: Options): void;
-declare namespace copy {}
+declare function copy(text: string, options?: Options): boolean;
+declare namespace copy { }
 export = copy;


### PR DESCRIPTION
I have added `copy` function return type.