### PR TITLE
remove all ranges before adding a range for copying

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function copy(text, options) {
     document.body.appendChild(mark);
 
     range.selectNode(mark);
+    selection.removeAllRanges();
     selection.addRange(range);
 
     var successful = document.execCommand('copy');


### PR DESCRIPTION
Merging ranges is deprecated for a while now https://www.chromestatus.com/features/6680566019653632.

Removing all ranges before adding was suggested in https://stackoverflow.com/a/43443101.