### PR TITLE
return result of clipboardData.setData

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,7 @@ function copy(text, options) {
     debug && console.error('unable to copy using execCommand: ', err);
     debug && console.warn('trying IE specific stuff');
     try {
-      window.clipboardData.setData('text', text);
-      success = true;
+      success = window.clipboardData.setData('text', text);
     } catch (err) {
       debug && console.error('unable to copy using clipboardData: ', err);
       debug && console.error('falling back to prompt');


### PR DESCRIPTION
On IE 11, window.clipboardData.setData() returns boolean indicating success or not, we should return it so as to provide a decent feedback.