### PR TITLE
Copy with a MIME type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ copy('Text', {
 |------|--------|-----|
 |options.debug  |false| `Boolean`. Optional. Enable output to console. |
 |options.message|Copy to clipboard: `#{key}`, Enter| `String`. Optional. Prompt message. `*` |
+|options.format|"text"|`String`. Optional. Set the MIME type of what you want to copy as. Use "text/HTML" to copy as HTML|
 
 `*` all occurrences of `#{key}` are replaced with `⌘+C` for macOS/iOS users, and `Ctrl+C` otherwise.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@
 interface Options {
   debug?: boolean;
   message?: string;
+  format?: string; // MIME type
 }
 
 declare function copy(text: string, options?: Options): boolean;

--- a/index.js
+++ b/index.js
@@ -44,6 +44,11 @@ function copy(text, options) {
     mark.style.userSelect = "text";
     mark.addEventListener("copy", function(e) {
       e.stopPropagation();
+      if (options.format) {
+        e.preventDefault();
+        e.clipboardData.clearData();
+        e.clipboardData.setData(options.format, text);
+      }
     });
 
     document.body.appendChild(mark);
@@ -60,7 +65,7 @@ function copy(text, options) {
     debug && console.error("unable to copy using execCommand: ", err);
     debug && console.warn("trying IE specific stuff");
     try {
-      window.clipboardData.setData("text", text);
+      window.clipboardData.setData(options.format || "text", text);
       success = true;
     } catch (err) {
       debug && console.error("unable to copy using clipboardData: ", err);


### PR DESCRIPTION
I needed a similar feature to the PR in #77 -- but I wanted to copy HTML instead of text/plain. So I implemented it in the way that @sudodoki recommended. We have been using this in our application for several weeks and it works correctly.