### PR TITLE
Add support for onCopy callback. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ copy('Text', {
 |options.debug  |false| `Boolean`. Optional. Enable output to console. |
 |options.message|Copy to clipboard: `#{key}`, Enter| `String`. Optional. Prompt message. `*` |
 |options.format|"text/html"| `String`. Optional. Set the MIME type of what you want to copy as. Use `text/html` to copy as HTML, `text/plain` to avoid inherited styles showing when pasted into rich text editor. |
+|options.onCopy|null| `function onCopy(clipboardData: object): void`. Optional. Receives the clipboardData element for adding custom behavior such as additional formats |
 
 `*` all occurrences of `#{key}` are replaced with `⌘+C` for macOS/iOS users, and `Ctrl+C` otherwise.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ interface Options {
   debug?: boolean;
   message?: string;
   format?: string; // MIME type
-  onCopy: function(clipboardData: object): void;
+  onCopy?: function(clipboardData: object): void;
 }
 
 declare function copy(text: string, options?: Options): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ interface Options {
   debug?: boolean;
   message?: string;
   format?: string; // MIME type
+  onCopy: function(clipboardData: object): void;
 }
 
 declare function copy(text: string, options?: Options): boolean;

--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ function copy(text, options) {
         e.clipboardData.clearData();
         e.clipboardData.setData(options.format, text);
       }
+      if (options.onCopy) {
+        e.preventDefault();
+        options.onCopy(e.clipboardData);
+      }
     });
 
     document.body.appendChild(mark);
@@ -66,6 +70,7 @@ function copy(text, options) {
     debug && console.warn("trying IE specific stuff");
     try {
       window.clipboardData.setData(options.format || "text", text);
+      options.onCopy && options.onCopy(window.clipboardData);
       success = true;
     } catch (err) {
       debug && console.error("unable to copy using clipboardData: ", err);


### PR DESCRIPTION
Fixes https://github.com/sudodoki/copy-to-clipboard/issues/81

supersedes https://github.com/sudodoki/copy-to-clipboard/pull/83

Allows setting different types of formats for specialized targets, which is supported according to spec - https://www.w3.org/TR/clipboard-apis/#override-copy

My use case is copying a URL.
When pasting in an email client I want the it to be pasted as an HTML anchor so it leads to the target.
When pasting in the browser URL I want it to be pasted as plain text.

I kept the format option for backward compatibility, but the new callback covers that as well.