### PR TITLE
Copying to excel line breaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ function copy(text, options) {
     range = document.createRange();
     selection = document.getSelection();
 
-    mark = document.createElement("span");
+    // mark = document.createElement("span");
+    // copy to excel line breaks
+    mark = document.createElement("pre");
     mark.textContent = text;
     // reset user styles for span element
     mark.style.all = "unset";


### PR DESCRIPTION
Replace the span label with the pre label. In order to solve the problem, the text that is copied and pasted into excel is also wrapped