### PR TITLE
fix: clearData with format to fix only can set one format clipboard data bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function copy(text, options) {
           var format = clipboardToIE11Formatting[options.format] || clipboardToIE11Formatting["default"]
           window.clipboardData.setData(format, text);
         } else { // all other browsers
-          e.clipboardData.clearData();
+          e.clipboardData.clearData(options.format);
           e.clipboardData.setData(options.format, text);
         }
       }


### PR DESCRIPTION
In this case, only `text/html` format can be set:
```
copyToClipboard(url, {
  format: 'text/plain',
});
copyToClipboard(`<a href="${url}">aaa</a>`, {
  format: 'text/html',
});
```
because the clipboardData has been cleaned when called each time.