### PR TITLE
fix: clearData with format to fix only can set one format clipboard data bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function copy(text, options) {
           var format = clipboardToIE11Formatting[options.format] || clipboardToIE11Formatting["default"]
           window.clipboardData.setData(format, text);
         } else { // all other browsers
-          e.clipboardData.clearData();
+          e.clipboardData.clearData(options.format);
           e.clipboardData.setData(options.format, text);
         }
       }

--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ function copy(text, options) {
         if (typeof e.clipboardData === "undefined") { // IE 11
           debug && console.warn("unable to use e.clipboardData");
           debug && console.warn("trying IE specific stuff");
-          window.clipboardData.clearData();
-          var format = clipboardToIE11Formatting[options.format] || clipboardToIE11Formatting["default"]
+          var format = clipboardToIE11Formatting[options.format] || clipboardToIE11Formatting["default"];
+          window.clipboardData.clearData(format);
           window.clipboardData.setData(format, text);
         } else { // all other browsers
           e.clipboardData.clearData(options.format);


### PR DESCRIPTION
In this case, only `text/html` format can be set to clipboard, and when we paste to a plain textarea it will be null:

```
copyToClipboard(url, {
  format: 'text/plain',
});
copyToClipboard(`<a href="${url}">aaa</a>`, {
  format: 'text/html',
});
```
because the clipboardData has been cleaned when called each time.

So we should only clear the current format when set data.