### PR TITLE
feat: update API to use navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Copy to clipboard [![Build Status](https://travis-ci.org/sudodoki/copy-to-clipboard.svg?branch=master)](https://travis-ci.org/sudodoki/copy-to-clipboard)
+# Copy to clipboard [![CI](https://github.com/sudodoki/copy-to-clipboard/actions/workflows/github-ci.yml/badge.svg)](https://github.com/sudodoki/copy-to-clipboard/actions/workflows/github-ci.yml)
 
-Simple module exposing `copy` function that will try to use [execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#) with fallback to IE-specific `clipboardData` interface and finally, resort to usual `prompt` with proper text content and message.
+Simple module exposing an async `copy` function that uses the [Async Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) (`navigator.clipboard`) in secure contexts (HTTPS / localhost), with automatic fallback to `document.execCommand('copy')` for non-secure contexts or older browsers.
 
 > If you are building using [Electron](http://electronjs.org/), use [their API](https://www.electronjs.org/docs/latest/api/clipboard).
 
@@ -9,55 +9,105 @@ Simple module exposing `copy` function that will try to use [execCommand](https:
 ```js
 import copy from 'copy-to-clipboard';
 
-copy('Text');
+await copy('Text');
 
 // Copy with options
-copy('Text', {
+await copy('Text', {
   debug: true,
   message: 'Press #{key} to copy',
+});
+
+// Copy as HTML (text/html + text/plain written simultaneously)
+await copy('<b>Hello <i>world</i></b>', { format: 'text/html' });
+
+// Custom plain-text fallback via onCopy
+await copy('<b>Hello <i>world</i></b>', {
+  format: 'text/html',
+  onCopy: () => new ClipboardItem({
+    'text/html': new Blob(['<b>Hello <i>world</i></b>'], { type: 'text/html' }),
+    'text/plain': new Blob(['Hello world'], { type: 'text/plain' }),
+  }),
 });
 ```
 
 # API
 
-`copy(text: string, options: object): boolean` &mdash; tries to copy text to clipboard. Returns `true` if no additional keystrokes were required from user (so, `execCommand`, IE's `clipboardData` worked) or `false`.
+`copy(text: string, options?: object): Promise<boolean>` — copies text to clipboard. Returns `true` on success, `false` if all paths failed (no additional keystrokes were required from the user).
 
-|Value |Default |Notes|
-|------|--------|-----|
-|options.debug  |false| `Boolean`. Optional. Enable output to console. |
-|options.message|Copy to clipboard: `#{key}`, Enter| `String`. Optional. Prompt message. `*` |
-|options.format|"text/html"| `String`. Optional. Set the MIME type of what you want to copy as. Use `text/html` to copy as HTML, `text/plain` to avoid inherited styles showing when pasted into rich text editor. |
-|options.onCopy|null| `function onCopy(clipboardData: object): void`. Optional. Receives the clipboardData element for adding custom behavior such as additional formats |
+> **v4 breaking change:** `copy()` is now async and returns `Promise<boolean>`. Use `await copy(...)` to get the result.
 
-`*` all occurrences of `#{key}` are replaced with `⌘+C` for macOS/iOS users, and `Ctrl+C` otherwise.
+## Options
 
-# [Browser support](http://caniuse.com/#feat=document-execcommand)
+| Value | Default | Notes |
+|-------|---------|-------|
+| `options.debug` | `false` | `Boolean`. Enable output to console. |
+| `options.message` | `'Copy to clipboard: #{key}, Enter'` | `String`. Prompt message used when `fallbackToPrompt` is enabled. All occurrences of `#{key}` are replaced with `⌘+C` on macOS or `Ctrl+C` otherwise. |
+| `options.format` | — | `String`. MIME type to copy as. Use `'text/html'` to copy rich text; `'text/plain'` to strip inherited styles when pasting into rich-text editors. When set alongside `'text/html'`, both `text/html` and `text/plain` are written simultaneously via `ClipboardItem`. |
+| `options.onCopy` | — | `(clipboardData: ClipboardItem \| DataTransfer) => ClipboardItem \| void`. Called before the write. On the async path, receives the constructed `ClipboardItem` and may return a new one to replace it (useful for custom MIME types or a different plain-text fallback). On the `execCommand` fallback path, receives the `DataTransfer` object; return value is ignored. |
+| `options.fallbackToPrompt` | `false` | `Boolean`. If `true`, shows a `window.prompt()` as a last resort when both `navigator.clipboard` and `execCommand` fail. Off by default in v4. |
 
-Works everywhere where `prompt`* is available. Works best (i.e. without additional keystrokes) in Chrome, FF, Safari 10+, and, supposedly, IE/Edge.
+## Copy path selection
 
-Note: **does not work on some older iOS devices.**  
-`*` – even though **Safari 8** has `prompt`, you cannot specify prefilled content for prompt modal – thus it **doesn't work** as expected.
+1. **`navigator.clipboard.writeText(text)`** — used when the page is a secure context (HTTPS / localhost), `navigator.clipboard` is available, and neither `options.format` nor `options.onCopy` is set.
+2. **`navigator.clipboard.write([ClipboardItem])`** — used in a secure context when `options.format` or `options.onCopy` is set. Builds a `ClipboardItem` with `text/plain` always present; adds the requested MIME type alongside it. `onCopy` may return a replacement `ClipboardItem`.
+3. **`execCommand('copy')` fallback** — used on non-HTTPS pages, when `navigator.clipboard` is unavailable, or when the async write throws. Uses a hidden `<span>` element. `preventDefault` is only called when `options.format` is set.
+4. **`window.prompt()` fallback** — opt-in via `options.fallbackToPrompt: true`.
+
+# Browser support
+
+| Browser | Minimum | Notes |
+|---------|---------|-------|
+| Chrome | 76+ | Full `ClipboardItem` + `write()` support |
+| Firefox | 127+ | Full `ClipboardItem` + `write()` landed in Firefox 127 (mid-2024) |
+| Safari | 13.1+ | `writeText()` and `write()` available |
+| Edge | 79+ | Chromium-based; same as Chrome |
+
+`execCommand` fallback retains support for non-HTTPS contexts and any browser that reaches the catch path.
+
+> **Note:** The async clipboard write must occur within a user gesture (click, keydown, etc.). This library is designed to be called from event handlers, so this constraint is normally satisfied automatically.
 
 # Installation
 
-+ Can be used as npm package and then leveraged using commonjs bundler/loader:
 ```
-npm i --save copy-to-clipboard
+npm i copy-to-clipboard
 ```
-+ Can be utilized using [wzrd.in](https://wzrd.in/). Add following script to your page:
+
+Available as CommonJS, ES module, and IIFE (for `<script>` tags):
+
+```js
+// ESM
+import copy from 'copy-to-clipboard';
+
+// CommonJS
+const copy = require('copy-to-clipboard');
+```
+
 ```html
-<script src="https://wzrd.in/standalone/copy-to-clipboard@latest" async></script>
+<!-- IIFE via CDN — exposes window.copyToClipboard -->
+<script src="https://unpkg.com/copy-to-clipboard/dist/index.global.js"></script>
 ```
-You will have `window.copyToClipboard` exposed for you to use.
 
-# UI components based on this package:
-+ [react-copy-to-clipboard](https://github.com/nkbt/react-copy-to-clipboard)
-+ [copy-button](https://github.com/sudodoki/copy-button)
+# TypeScript
 
-# See also:
-+ [clipboard-copy](https://github.com/feross/clipboard-copy) by [@feross](https://github.com/feross)
-+ [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Browser_Compatibility)
-+ [April 2015 update on Cut and Copy Commands](http://updates.html5rocks.com/2015/04/cut-and-copy-commands)
+Built-in declarations are included for both CommonJS and ESM consumers.
+
+```ts
+import copy from 'copy-to-clipboard';
+import type { Options } from 'copy-to-clipboard';
+
+const result: boolean = await copy('text');
+```
+
+# UI components based on this package
+
+- [react-copy-to-clipboard](https://github.com/nkbt/react-copy-to-clipboard)
+- [copy-button](https://github.com/sudodoki/copy-button)
+
+# See also
+
+- [clipboard-copy](https://github.com/feross/clipboard-copy) by [@feross](https://github.com/feross)
+- [Async Clipboard API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)
+- [ClipboardItem (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem)
 
 # Running Tests
 
@@ -66,32 +116,31 @@ End-to-end tests are powered by [Nightwatch](https://nightwatchjs.org/) using na
 ```
 npm i
 npm test               # Chrome (default)
-npm run test:chrome
 npm run test:firefox
 npm run test:safari
-npm run test:all       # Chrome, Firefox, and Safari in sequence
+npm run test:edge
+npm run test:all       # all local browsers
 ```
 
-**Safari prerequisite:** Safari requires "Allow Remote Automation" to be enabled before `test:safari` will work. See [Testing with WebDriver in Safari](https://developer.apple.com/documentation/webkit/testing-with-webdriver-in-safari) on Apple Developer Documentation for instructions.
+**Safari prerequisite:** enable "Allow Remote Automation" in Safari's Develop menu. See [Testing with WebDriver in Safari](https://developer.apple.com/documentation/webkit/testing-with-webdriver-in-safari).
 
 ## CI
 
-**Firefox** tests run automatically on every push to `main` / `4.0.0-branch` and on pull requests via GitHub Actions (Ubuntu runner, headless).
+**Chrome, Firefox, and Edge** tests run automatically on every push to `master` and on pull requests via GitHub Actions (Ubuntu runner, headless).
 
-**Cross-browser** tests (Firefox, Chrome, Safari, Edge) run on [LambdaTest](https://www.lambdatest.com/) automatically on every version tag (`v*`) and can be triggered manually from the Actions tab with per-browser toggles. Requires `LT_USERNAME` and `LT_ACCESS_KEY` repository secrets.
-
-To run the LambdaTest suite locally (requires credentials in environment):
+**Cross-browser** tests (Chrome, Firefox, Safari, Edge) run on [LambdaTest](https://www.lambdatest.com/) automatically on every version tag (`v*`) and can be triggered manually from the Actions tab. Requires `LT_USERNAME` and `LT_ACCESS_KEY` repository secrets.
 
 ```
-npm run test:lt:firefox
 npm run test:lt:chrome
+npm run test:lt:firefox
 npm run test:lt:safari
 npm run test:lt:edge
 npm run test:lt:all
 ```
-# Typescript
-This library has built-in Typescript definitions.
 
-```
-import * as copy from 'copy-to-clipboard';
-```
+# Breaking changes in v4
+
+1. **`copy()` is now async** — returns `Promise<boolean>` instead of `boolean`. Wrap call sites with `await`.
+2. **IE11 support dropped** — `window.clipboardData` path removed.
+3. **`window.prompt()` fallback is opt-in** — set `options.fallbackToPrompt: true` to enable.
+4. **Build output moved to `dist/`** — direct `require('copy-to-clipboard/index.js')` paths will break; use the package name only.

--- a/e2e_helpers/assertions/assertRichBuffer.js
+++ b/e2e_helpers/assertions/assertRichBuffer.js
@@ -2,7 +2,7 @@
 const getModifierKey = require('../modifier-key');
 
 exports.assertion = function(expected) {
-  this.message = "Checking buffer contents";
+  this.message = "Checking rich buffer contents (innerHTML)";
   this.expected = (expected instanceof RegExp) ? "to match " + expected : expected;
 
   this.pass = function(value) {
@@ -17,8 +17,12 @@ exports.assertion = function(expected) {
 
   this.command = function(callback) {
     return this.api
-      .waitForElementVisible('[data-test="placeholder"]', 500)
-      .click('[data-test="placeholder"]')
+      .waitForElementVisible('[data-test="rich-placeholder"]', 500)
+      // Clear existing content first
+      .execute(function() {
+        document.querySelector('[data-test="rich-placeholder"]').innerHTML = '';
+      })
+      .click('[data-test="rich-placeholder"]')
       .perform(function() {
         const key = this.Keys[getModifierKey()];
         return this.actions()
@@ -26,10 +30,14 @@ exports.assertion = function(expected) {
           .perform();
       })
       .waitUntil(async function() {
-        const value = await this.getValue('[data-test="placeholder"]');
-        return value !== '';
+        const result = await this.execute(function() {
+          return document.querySelector('[data-test="rich-placeholder"]').innerHTML;
+        });
+        return result !== '';
       }, parseInt(process.env.ASSERT_BUFFER_TIMEOUT, 10) || 500)
-      .getValue('[data-test="placeholder"]', function(result) {
+      .execute(function() {
+        return document.querySelector('[data-test="rich-placeholder"]').innerHTML;
+      }, [], function(result) {
         callback(result.value);
       });
   };

--- a/example/index.html
+++ b/example/index.html
@@ -8,6 +8,7 @@
 <body>
   <h1 data-test="heading"><a href="http://github.com/sudodoki/copy-to-clipboard">copy-to-clipboard Repo</a></h1>
   <textarea data-test="placeholder"></textarea>
+  <div data-test="rich-placeholder" contenteditable="true" style="min-height:2em;border:1px solid #ccc;padding:4px;margin:4px 0;"></div>
   <div class="container">
     <h2 id="basic-text">Basic text copy</h2>
     <textarea disabled class="code half">copyToClipboard("Hello, I'm new content from your clipboard")</textarea>
@@ -39,27 +40,64 @@ for us to copy</textarea>
     </div>
   </div>
   <hr>
+  <div class="container">
+    <h2 id="rich-text">Rich text (HTML) copy</h2>
+    <textarea disabled class="code half">copyToClipboard('&lt;b&gt;Hello &lt;i&gt;world&lt;/i&gt;&lt;/b&gt;', { format: 'text/html' })</textarea>
+    <div class="half">
+      <button data-test="init-rich-text">Click to copy rich text</button>
+    </div>
+  </div>
+  <hr>
+  <div class="container">
+    <h2 id="rich-text-custom-plain">Rich text with custom plain fallback</h2>
+    <textarea disabled class="code half">copyToClipboard('&lt;b&gt;Hello &lt;i&gt;world&lt;/i&gt;&lt;/b&gt;', {
+  format: 'text/html',
+  onCopy: () =&gt; new ClipboardItem({
+    'text/html': new Blob(['&lt;b&gt;Hello &lt;i&gt;world&lt;/i&gt;&lt;/b&gt;'], { type: 'text/html' }),
+    'text/plain': new Blob(['Hello plain world'], { type: 'text/plain' }),
+  })
+})</textarea>
+    <div class="half">
+      <button data-test="init-rich-text-custom-plain">Click to copy rich text with custom plain</button>
+    </div>
+  </div>
+  <hr>
   <script src="./index.js"></script>
   <script>
     document.querySelector('#basic-text ~ .half button')
-      .addEventListener('click', function () {
-        copyToClipboard("Hello, I'm new content from your clipboard")
+      .addEventListener('click', async function () {
+        await copyToClipboard("Hello, I'm new content from your clipboard");
       });
     (function() {
       var multilineContainer = document.querySelector('#multiline-text + textarea');
       document.querySelector('#multiline-text ~ .half button')
-        .addEventListener('click', function () {
-          copyToClipboard(multilineContainer.textContent)
-        })
+        .addEventListener('click', async function () {
+          await copyToClipboard(multilineContainer.textContent);
+        });
     })();
     (function() {
       var markupContainer = document.querySelector('#multiline-markup + textarea');
       document.querySelector('#multiline-markup ~ .half button')
-        .addEventListener('click', function () {
-          copyToClipboard(markupContainer.textContent)
-        })
+        .addEventListener('click', async function () {
+          await copyToClipboard(markupContainer.textContent);
+        });
     })();
-
+    document.querySelector('#rich-text ~ .half button')
+      .addEventListener('click', async function () {
+        await copyToClipboard('<b>Hello <i>world</i></b>', { format: 'text/html' });
+      });
+    document.querySelector('#rich-text-custom-plain ~ .half button')
+      .addEventListener('click', async function () {
+        await copyToClipboard('<b>Hello <i>world</i></b>', {
+          format: 'text/html',
+          onCopy: function() {
+            return new ClipboardItem({
+              'text/html': new Blob(['<b>Hello <i>world</i></b>'], { type: 'text/html' }),
+              'text/plain': new Blob(['Hello plain world'], { type: 'text/plain' }),
+            });
+          },
+        });
+      });
   </script>
 </body>
 </html>

--- a/example/index.js
+++ b/example/index.js
@@ -48,44 +48,65 @@ var copyToClipboard = (() => {
     "index.js"(exports, module) {
       var deselectCurrent = require_toggle_selection();
       var defaultMessage = "Copy to clipboard: #{key}, Enter";
-      function format(message) {
-        var copyKey = (/mac os x/i.test(navigator.userAgent) ? "\u2318" : "Ctrl") + "+C";
+      function formatPromptMessage(message) {
+        var isMac = navigator.userAgentData ? /mac/i.test(navigator.userAgentData.platform) : /mac os x/i.test(navigator.userAgent);
+        var copyKey = (isMac ? "\u2318" : "Ctrl") + "+C";
         return message.replace(/#{\s*key\s*}/g, copyKey);
       }
-      function copy(text, options) {
-        var debug, message, reselectPrevious, range, selection, mark, success = false;
-        if (!options) {
-          options = {};
+      function buildClipboardItem(text, format) {
+        var items = {};
+        items["text/plain"] = new Blob([text], { type: "text/plain" });
+        if (format === "text/html") {
+          items["text/html"] = new Blob([text], { type: "text/html" });
+        } else if (format && format !== "text/plain") {
+          items[format] = new Blob([text], { type: format });
         }
-        debug = options.debug || false;
+        return new ClipboardItem(items);
+      }
+      async function copyViaClipboardAPI(text, options) {
+        if (!options.format && !options.onCopy) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+        var item = buildClipboardItem(text, options.format);
+        if (options.onCopy) {
+          item = options.onCopy(item) || item;
+        }
+        await navigator.clipboard.write([item]);
+        return true;
+      }
+      function createHiddenSpan(text, options) {
+        var mark = document.createElement("span");
+        mark.textContent = text;
+        mark.ariaHidden = "true";
+        mark.style.all = "unset";
+        mark.style.position = "fixed";
+        mark.style.top = 0;
+        mark.style.clip = "rect(0, 0, 0, 0)";
+        mark.style.whiteSpace = "pre";
+        mark.style.webkitUserSelect = "text";
+        mark.style.MozUserSelect = "text";
+        mark.style.msUserSelect = "text";
+        mark.style.userSelect = "text";
+        mark.addEventListener("copy", function(e) {
+          e.stopPropagation();
+          if (options.format) {
+            e.preventDefault();
+            e.clipboardData.setData(options.format, text);
+          }
+          if (options.onCopy) {
+            options.onCopy(e.clipboardData);
+          }
+        });
+        return mark;
+      }
+      function copyViaExecCommand(text, options) {
+        var reselectPrevious = deselectCurrent();
+        var range = document.createRange();
+        var selection = document.getSelection();
+        var mark = createHiddenSpan(text, options);
+        var success = false;
         try {
-          reselectPrevious = deselectCurrent();
-          range = document.createRange();
-          selection = document.getSelection();
-          mark = document.createElement("span");
-          mark.textContent = text;
-          mark.ariaHidden = "true";
-          mark.style.all = "unset";
-          mark.style.position = "fixed";
-          mark.style.top = 0;
-          mark.style.clip = "rect(0, 0, 0, 0)";
-          mark.style.whiteSpace = "pre";
-          mark.style.webkitUserSelect = "text";
-          mark.style.MozUserSelect = "text";
-          mark.style.msUserSelect = "text";
-          mark.style.userSelect = "text";
-          mark.addEventListener("copy", function(e) {
-            e.stopPropagation();
-            if (options.format) {
-              e.preventDefault();
-              e.clipboardData.clearData();
-              e.clipboardData.setData(options.format, text);
-            }
-            if (options.onCopy) {
-              e.preventDefault();
-              options.onCopy(e.clipboardData);
-            }
-          });
           document.body.appendChild(mark);
           range.selectNodeContents(mark);
           selection.addRange(range);
@@ -94,25 +115,43 @@ var copyToClipboard = (() => {
             throw new Error("copy command was unsuccessful");
           }
           success = true;
-        } catch (err) {
-          debug && console.error("unable to copy using execCommand: ", err);
-          debug && console.error("falling back to prompt");
-          message = format("message" in options ? options.message : defaultMessage);
-          window.prompt(message, text);
         } finally {
-          if (selection) {
-            if (typeof selection.removeRange == "function") {
-              selection.removeRange(range);
-            } else {
-              selection.removeAllRanges();
-            }
+          if (typeof selection.removeRange == "function") {
+            selection.removeRange(range);
+          } else {
+            selection.removeAllRanges();
           }
-          if (mark) {
-            document.body.removeChild(mark);
-          }
+          document.body.removeChild(mark);
           reselectPrevious();
         }
         return success;
+      }
+      async function copy(text, options) {
+        if (!options) {
+          options = {};
+        }
+        var debug = options.debug || false;
+        if (window.isSecureContext && navigator.clipboard) {
+          try {
+            return await copyViaClipboardAPI(text, options);
+          } catch (err) {
+            debug && console.error("unable to copy using navigator.clipboard: ", err);
+            debug && console.warn("falling back to execCommand");
+          }
+        } else {
+          debug && !window.isSecureContext && console.warn("copy-to-clipboard: navigator.clipboard requires a secure context (HTTPS/localhost). Falling back to execCommand.");
+        }
+        try {
+          return copyViaExecCommand(text, options);
+        } catch (err) {
+          debug && console.error("unable to copy using execCommand: ", err);
+          debug && console.error("falling back to prompt");
+          if (options.fallbackToPrompt) {
+            var message = formatPromptMessage("message" in options ? options.message : defaultMessage);
+            window.prompt(message, text);
+          }
+        }
+        return false;
       }
       module.exports = copy;
     }

--- a/example/index.js
+++ b/example/index.js
@@ -56,9 +56,7 @@ var copyToClipboard = (() => {
       function buildClipboardItem(text, format) {
         var items = {};
         items["text/plain"] = new Blob([text], { type: "text/plain" });
-        if (format === "text/html") {
-          items["text/html"] = new Blob([text], { type: "text/html" });
-        } else if (format && format !== "text/plain") {
+        if (format && format !== "text/plain") {
           items[format] = new Blob([text], { type: format });
         }
         return new ClipboardItem(items);

--- a/index.d.mts
+++ b/index.d.mts
@@ -5,10 +5,25 @@ interface Options {
   debug?: boolean;
   message?: string;
   format?: string; // MIME type
-  onCopy?: (clipboardData: object) => void;
+  /**
+   * Intercept and optionally replace the clipboard item before writing.
+   *
+   * - On the async path (`navigator.clipboard`): receives a `ClipboardItem` and
+   *   may return a new `ClipboardItem` to replace it.
+   * - On the execCommand fallback path: receives the `DataTransfer` object from
+   *   the copy event. Return value is ignored; use `clipboardData.setData()` to
+   *   override content (requires `options.format` to be set so `preventDefault`
+   *   is called).
+   */
+  onCopy?: (clipboardData: ClipboardItem | DataTransfer) => ClipboardItem | void;
+  /**
+   * Enable the `window.prompt()` fallback when both `navigator.clipboard` and
+   * `execCommand` fail. Off by default in v4.
+   */
+  fallbackToPrompt?: boolean;
 }
 
-declare function copy(text: string, options?: Options): boolean;
+declare function copy(text: string, options?: Options): Promise<boolean>;
 
 export default copy;
 export type { Options };

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,10 +6,25 @@ interface Options {
   debug?: boolean;
   message?: string;
   format?: string; // MIME type
-  onCopy?: (clipboardData: object) => void;
+  /**
+   * Intercept and optionally replace the clipboard item before writing.
+   *
+   * - On the async path (`navigator.clipboard`): receives a `ClipboardItem` and
+   *   may return a new `ClipboardItem` to replace it.
+   * - On the execCommand fallback path: receives the `DataTransfer` object from
+   *   the copy event. Return value is ignored; use `clipboardData.setData()` to
+   *   override content (requires `options.format` to be set so `preventDefault`
+   *   is called).
+   */
+  onCopy?: (clipboardData: ClipboardItem | DataTransfer) => ClipboardItem | void;
+  /**
+   * Enable the `window.prompt()` fallback when both `navigator.clipboard` and
+   * `execCommand` fail. Off by default in v4.
+   */
+  fallbackToPrompt?: boolean;
 }
 
-declare function copy(text: string, options?: Options): boolean;
+declare function copy(text: string, options?: Options): Promise<boolean>;
 declare namespace copy { }
 export = copy;
 export type { Options };

--- a/index.js
+++ b/index.js
@@ -4,61 +4,77 @@ var deselectCurrent = require("toggle-selection");
 
 var defaultMessage = "Copy to clipboard: #{key}, Enter";
 
-function format(message) {
-  var copyKey = (/mac os x/i.test(navigator.userAgent) ? "⌘" : "Ctrl") + "+C";
+function formatPromptMessage(message) {
+  var isMac = navigator.userAgentData
+    ? /mac/i.test(navigator.userAgentData.platform)
+    : /mac os x/i.test(navigator.userAgent);
+  var copyKey = (isMac ? "⌘" : "Ctrl") + "+C";
   return message.replace(/#{\s*key\s*}/g, copyKey);
 }
 
-function copy(text, options) {
-  var debug,
-    message,
-    reselectPrevious,
-    range,
-    selection,
-    mark,
-    success = false;
-  if (!options) {
-    options = {};
+function buildClipboardItem(text, format) {
+  var items = {};
+  items['text/plain'] = new Blob([text], { type: 'text/plain' });
+  if (format && format !== 'text/plain') {
+    items[format] = new Blob([text], { type: format });
   }
-  debug = options.debug || false;
+  return new ClipboardItem(items);
+}
+
+async function copyViaClipboardAPI(text, options) {
+  if (!options.format && !options.onCopy) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  var item = buildClipboardItem(text, options.format);
+  if (options.onCopy) {
+    item = options.onCopy(item) || item;
+  }
+  await navigator.clipboard.write([item]);
+  return true;
+}
+
+function createHiddenSpan(text, options) {
+  var mark = document.createElement("span");
+  mark.textContent = text;
+  // avoid screen readers from reading out loud the text
+  mark.ariaHidden = "true";
+  // reset user styles for span element
+  mark.style.all = "unset";
+  // prevents scrolling to the end of the page
+  mark.style.position = "fixed";
+  mark.style.top = 0;
+  mark.style.clip = "rect(0, 0, 0, 0)";
+  // used to preserve spaces and line breaks
+  mark.style.whiteSpace = "pre";
+  // do not inherit user-select (it may be `none`)
+  mark.style.webkitUserSelect = "text";
+  mark.style.MozUserSelect = "text";
+  mark.style.msUserSelect = "text";
+  mark.style.userSelect = "text";
+  mark.addEventListener("copy", function(e) {
+    e.stopPropagation();
+    if (options.format) {
+      e.preventDefault();
+      e.clipboardData.setData(options.format, text);
+    }
+    if (options.onCopy) {
+      options.onCopy(e.clipboardData);
+    }
+  });
+  return mark;
+}
+
+function copyViaExecCommand(text, options) {
+  var reselectPrevious = deselectCurrent();
+  var range = document.createRange();
+  var selection = document.getSelection();
+  var mark = createHiddenSpan(text, options);
+  var success = false;
+
   try {
-    reselectPrevious = deselectCurrent();
-
-    range = document.createRange();
-    selection = document.getSelection();
-
-    mark = document.createElement("span");
-    mark.textContent = text;
-    // avoid screen readers from reading out loud the text
-    mark.ariaHidden = "true"
-    // reset user styles for span element
-    mark.style.all = "unset";
-    // prevents scrolling to the end of the page
-    mark.style.position = "fixed";
-    mark.style.top = 0;
-    mark.style.clip = "rect(0, 0, 0, 0)";
-    // used to preserve spaces and line breaks
-    mark.style.whiteSpace = "pre";
-    // do not inherit user-select (it may be `none`)
-    mark.style.webkitUserSelect = "text";
-    mark.style.MozUserSelect = "text";
-    mark.style.msUserSelect = "text";
-    mark.style.userSelect = "text";
-    mark.addEventListener("copy", function(e) {
-      e.stopPropagation();
-      if (options.format) {
-        e.preventDefault();
-        e.clipboardData.clearData();
-        e.clipboardData.setData(options.format, text);
-      }
-      if (options.onCopy) {
-        e.preventDefault();
-        options.onCopy(e.clipboardData);
-      }
-    });
-
     document.body.appendChild(mark);
-
     range.selectNodeContents(mark);
     selection.addRange(range);
 
@@ -67,27 +83,51 @@ function copy(text, options) {
       throw new Error("copy command was unsuccessful");
     }
     success = true;
-  } catch (err) {
-    debug && console.error("unable to copy using execCommand: ", err);
-    debug && console.error("falling back to prompt");
-    message = format("message" in options ? options.message : defaultMessage);
-    window.prompt(message, text);
   } finally {
-    if (selection) {
-      if (typeof selection.removeRange == "function") {
-        selection.removeRange(range);
-      } else {
-        selection.removeAllRanges();
-      }
+    if (typeof selection.removeRange == "function") {
+      selection.removeRange(range);
+    } else {
+      selection.removeAllRanges();
     }
-
-    if (mark) {
-      document.body.removeChild(mark);
-    }
+    document.body.removeChild(mark);
     reselectPrevious();
   }
 
   return success;
+}
+
+async function copy(text, options) {
+  if (!options) {
+    options = {};
+  }
+  var debug = options.debug || false;
+
+  // --- Async Clipboard API path (secure context only) ---
+  if (window.isSecureContext && navigator.clipboard) {
+    try {
+      return await copyViaClipboardAPI(text, options);
+    } catch (err) {
+      debug && console.error("unable to copy using navigator.clipboard: ", err);
+      debug && console.warn("falling back to execCommand");
+    }
+  } else {
+    debug && !window.isSecureContext &&
+      console.warn("copy-to-clipboard: navigator.clipboard requires a secure context (HTTPS/localhost). Falling back to execCommand.");
+  }
+
+  // --- execCommand fallback ---
+  try {
+    return copyViaExecCommand(text, options);
+  } catch (err) {
+    debug && console.error("unable to copy using execCommand: ", err);
+    debug && console.error("falling back to prompt");
+    if (options.fallbackToPrompt) {
+      var message = formatPromptMessage("message" in options ? options.message : defaultMessage);
+      window.prompt(message, text);
+    }
+  }
+
+  return false;
 }
 
 module.exports = copy;

--- a/tests/04_rich-text.js
+++ b/tests/04_rich-text.js
@@ -1,0 +1,13 @@
+'use strict';
+module.exports = {
+  'Rich Text (HTML) Copy' : function (browser) {
+    browser
+      .page.helper().resetBuffer()
+      .url(browser.launchUrl)
+      .waitForElementVisible('[data-test="init-rich-text"]', 1000)
+      .click('[data-test="init-rich-text"]')
+      // HTML paste target is a contenteditable div, not a textarea
+      .assert.assertRichBuffer(/<b>|<i>|<strong>|<em>/i)
+      .end();
+  }
+};


### PR DESCRIPTION
New version is using `navigator.clipboard.write` by default